### PR TITLE
Fixed missing db info.

### DIFF
--- a/Uconomy.cs
+++ b/Uconomy.cs
@@ -14,13 +14,6 @@ namespace fr34kyn01535.Uconomy
 
         protected override void Load()
         {
-            Configuration.Instance.DatabaseAddress = "localhost";
-            Configuration.Instance.DatabaseUsername = "unturned";
-            Configuration.Instance.DatabasePassword = "password";
-            Configuration.Instance.DatabaseName = "unturned";
-            Configuration.Instance.DatabaseTableName = "uconomy";
-            Configuration.Instance.DatabasePort = 3306;
-
             Instance = this;
             Database = new DatabaseManager();
         }


### PR DESCRIPTION
When a plugin requested the config values of the database, they would get the default that was set on the load here. Issue has been there since 3d8235f